### PR TITLE
Update SONY_PSX.yml

### DIFF
--- a/platform/SONY_PSX.yml
+++ b/platform/SONY_PSX.yml
@@ -3,7 +3,7 @@ Metadata:
   platform_releasedate: '1994-12-03'
   platform_shortname: psx
   platform_company: Sony
-  platform_type: Handheld
+  platform_type: Home
 MaximumInputs: 2
 FriendlyName: PlayStation
 FileTypes: 


### PR DESCRIPTION
Edited the psx platform_type from "Handheld" to "Home" as the psx is a home console, not a handheld device.

**Affected IDs:**
**Non Breaking Change:** 


**Rationale:**


**Changes Made:**