### PR TITLE
SEGA_DC: Deprecate use of rawtrack

### DIFF
--- a/platform/SEGA_DC.yml
+++ b/platform/SEGA_DC.yml
@@ -7,8 +7,8 @@ Metadata:
 MaximumInputs: 4
 FriendlyName: Sega Dreamcast
 FileTypes:
-    .bin: 'application/vnd.stone-romfile.sega.dc-rawtrack'
-    .raw: 'application/vnd.stone-romfile.sega.dc-rawtrack'
+    .bin: 'application/vnd.stone-romfile.sega.dc-discimage'
+    .raw: 'application/vnd.stone-romfile.sega.dc-discimage'
     .gdi: 'application/vnd.stone-romfile.sega.dc-gdi'
     .elf: 'application/vnd.stone-romfile.sega.dc-elf'
     .cdi: 'application/vnd.stone-romfile.sega.dc-discjuggler'


### PR DESCRIPTION
**Affected IDs:**
* SEGA_DC
**Non Breaking Change:** This is a breaking change
**Rationale:** The `.bin` and `.raw` formats should be `-discimage`.
**Changes Made:**
* `-rawtrack` mimetypes changed to `-discimage`